### PR TITLE
fixed bug that prevented requiring this as a node module

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,5 +35,5 @@
         "colorbrewer.css",
         "colorbrewer.js"
     ],
-    "main": "index.js"
+    "main": "colorbrewer.js"
 }


### PR DESCRIPTION
I was unable to require this module using browserify so I fixed that in this PR
