### PR TITLE
Bump to version 1.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "colorbrewer",
-    "version": "0.0.2",
+    "version": "1.0.0",
     "description": "A shim module of colorbrewer2 by Cythina Brewer for browserify",
     "keywords": [
         "colors",


### PR DESCRIPTION
This project has been around for a while and the API is very stable. Can you bump to 1.0.0 to reflect this? 

From the [semver spec](http://semver.org/):

> Major version zero (0.y.z) is for initial development. Anything may change at any time. The public API should not be considered stable.

and

> Version 1.0.0 defines the public API.

Moving to 1.0.0 tells users that your public API is stable and the project is safe for use with [semver ranges](http://developer.telerik.com/featured/mystical-magical-semver-ranges-used-npm-bower/).

Thanks!